### PR TITLE
Less confrontational Instrument instance

### DIFF
--- a/src/Instrument/ClientClass.hs
+++ b/src/Instrument/ClientClass.hs
@@ -39,7 +39,7 @@ import qualified Instrument.Client      as I
 class HasInstrument m where
   getInstrument :: m I.Instrument
 
-instance (MonadReader I.Instrument m) => HasInstrument m where
+instance (Monad m) => HasInstrument (ReaderT I.Instrument m) where
   getInstrument = ask
 
 

--- a/src/Instrument/Worker.hs
+++ b/src/Instrument/Worker.hs
@@ -4,6 +4,7 @@ module Instrument.Worker
     ( initWorkerCSV
     , initWorkerGraphite
     , work
+    , AggProcess
     ) where
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
First off, totally open to solving this another way if there's a better way, this just worked for my project. Currently, instrument has a very broad default instance for HasInstrument. If you use this in a stack that's based on constraints (i.e. MonadReader r m, HasAppState r), GHC seems to get tripped up, I think because that context could also possibly contain a MonadReader Instrument instance. It will refuse to select an instance. 

In Katip, for example, we create a newtype specifically for this case: https://github.com/Soostone/katip/blob/master/katip/src/Katip/Core.hs#L515 Alternatively, we could also just not provide any instances for HasInstrument and leave that to the user.
