### PR TITLE
Quantile control

### DIFF
--- a/instrument-cloudwatch/src/Instrument/CloudWatch.hs
+++ b/instrument-cloudwatch/src/Instrument/CloudWatch.hs
@@ -27,6 +27,7 @@ import           Data.List.NonEmpty                   (NonEmpty (..))
 import qualified Data.List.NonEmpty                   as NE
 import qualified Data.Map                             as M
 import           Data.Monoid
+import           Data.Semigroup                       (sconcat)
 import           Data.Text                            (Text)
 import qualified Data.Text                            as T
 import           Data.Time.Clock
@@ -95,8 +96,9 @@ startWorker CloudWatchICfg {..} q = go
           maggs <- atomically (slurpTBMQueue q)
           case maggs of
             Just rawAggs -> do
-              FT.forM_ (splitNE maxDatums rawAggs) $ \aggs -> do
-                let pmd = putMetricData cwiNamespace & pmdMetricData .~ FT.toList (toDatum A.<$> aggs)
+              let datums = sconcat (toDatum A.<$> rawAggs)
+              FT.forM_ (splitNE maxDatums datums) $ \datumPage -> do
+                let pmd = putMetricData cwiNamespace & pmdMetricData .~ FT.toList datumPage
                 void (runResourceT (awsRetry (runAWS cwiEnv (send pmd))))
               go
             Nothing -> return ()
@@ -116,24 +118,39 @@ splitNE n xs
 
 
 -------------------------------------------------------------------------------
---TODO: publish quantiles
-toDatum :: Aggregated -> MetricDatum
-toDatum a = md & mdTimestamp .~ Just ts
-                              & mdStatisticValues .~ ss
-                              & mdValue .~ val
-                              & mdDimensions .~ dims
-  where md = metricDatum (T.pack (metricName (aggName a)))
-        ts = aggTS a ^. timeDouble
-        ss = case aggPayload a of
-               AggStats stats -> Just (toSS stats)
-               _              -> Nothing
-        val = case aggPayload a of
-                AggCount n -> Just (fromIntegral n)
-                _          -> Nothing
-        dims = uncurry mkDim <$> take maxDimensions (M.toList (aggDimensions a))
-        mkDim (DimensionName dn) (DimensionValue dv) = dimension dn dv
-        -- | <http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html>
-        maxDimensions = 10
+-- | Expands the aggregated stats into datums. In most cases, this
+-- will result in 1 datum. If the payload is an 'AggStats' and
+-- contains quantiles, those will be emitted as individual metrics
+-- with the quantile appended, e.g. metricName.p90
+toDatum :: Aggregated -> NonEmpty MetricDatum
+toDatum a =
+  baseDatum :| quantileDatums
+  where
+    baseDatum =
+     mkDatum baseMetricName $ case aggPayload a of
+       AggStats stats -> Right (toSS stats)
+       AggCount n     -> Left (fromIntegral n)
+    mkDatum name dValOrStats =
+      let base = metricDatum (T.pack name)
+            & mdTimestamp .~ Just ts
+            & mdDimensions .~ dims
+         -- Value and stats are mutually exclusive
+      in case dValOrStats of
+           Left dVal    -> base & mdValue ?~ dVal
+           Right dStats -> base & mdStatisticValues ?~ dStats
+    quantileDatums = uncurry mkQuantileDatum <$> quantiles
+    mkQuantileDatum :: Int -> Double -> MetricDatum
+    mkQuantileDatum quantile val =
+      mkDatum (baseMetricName <> ".p" <> show quantile) (Left val)
+    quantiles = case aggPayload a of
+      AggStats stats -> M.toList (squantiles stats)
+      AggCount _     -> []
+    baseMetricName = (metricName (aggName a))
+    ts = aggTS a ^. timeDouble
+    dims = uncurry mkDim <$> take maxDimensions (M.toList (aggDimensions a))
+    mkDim (DimensionName dn) (DimensionValue dv) = dimension dn dv
+    -- | <http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html>
+    maxDimensions = 10
 
 
 -------------------------------------------------------------------------------

--- a/instrument/src/Instrument/Client.hs
+++ b/instrument/src/Instrument/Client.hs
@@ -9,6 +9,7 @@ module Instrument.Client
     , incrementI
     , countI
     , timerMetricName
+    , stripTimerPrefix
     , timerMetricNamePrefix
     ) where
 
@@ -19,7 +20,7 @@ import           Control.Monad.IO.Class
 import qualified Data.ByteString.Char8  as B
 import           Data.IORef             (IORef, atomicModifyIORef, newIORef,
                                          readIORef)
-import           Data.List              (isPrefixOf)
+import           Data.List              (isPrefixOf, stripPrefix)
 import qualified Data.Map               as M
 import           Data.Monoid
 import qualified Data.SafeCopy          as SC
@@ -206,6 +207,13 @@ timerMetricName name@(MetricName nameS) =
   if timerMetricNamePrefix `isPrefixOf` nameS
      then name
      else MetricName (timerMetricNamePrefix <> nameS)
+
+
+-------------------------------------------------------------------------------
+stripTimerPrefix :: MetricName -> MetricName
+stripTimerPrefix (MetricName n) = case stripPrefix timerMetricNamePrefix n of
+  Just unprefixed -> MetricName unprefixed
+  Nothing         -> MetricName n
 
 
 -------------------------------------------------------------------------------

--- a/instrument/src/Instrument/Client.hs
+++ b/instrument/src/Instrument/Client.hs
@@ -191,12 +191,10 @@ timeI
   -> Instrument
   -> m a
   -> m a
-timeI name hostDimPolicy rawDims i act = do
+timeI nm hostDimPolicy rawDims i act = do
   (!secs, !res) <- TM.time act
   submitTime nm hostDimPolicy rawDims secs i
   return res
-  where
-    nm = timerMetricName name
 
 
 -------------------------------------------------------------------------------
@@ -210,6 +208,9 @@ timerMetricName name = MetricName ("time." ++ metricName name)
 --
 -- Also, you may be pulling time details from some external source
 -- that you can't measure with 'timeI' yourself.
+--
+-- Note: for legacy purposes, metric name will have "time." prepended
+-- to it.
 submitTime
   :: (MonadIO m)
   => MetricName
@@ -219,8 +220,10 @@ submitTime
   -- ^ Time in seconds
   -> Instrument
   -> m ()
-submitTime nm hostDimPolicy rawDims secs i =
+submitTime nameRaw hostDimPolicy rawDims secs i =
   liftIO $ sampleI nm hostDimPolicy rawDims secs i
+  where
+    nm = timerMetricName nameRaw
 
 
 -------------------------------------------------------------------------------

--- a/instrument/src/Instrument/Client.hs
+++ b/instrument/src/Instrument/Client.hs
@@ -9,6 +9,7 @@ module Instrument.Client
     , incrementI
     , countI
     , timerMetricName
+    , timerMetricNamePrefix
     ) where
 
 -------------------------------------------------------------------------------
@@ -18,7 +19,9 @@ import           Control.Monad.IO.Class
 import qualified Data.ByteString.Char8  as B
 import           Data.IORef             (IORef, atomicModifyIORef, newIORef,
                                          readIORef)
+import           Data.List              (isPrefixOf)
 import qualified Data.Map               as M
+import           Data.Monoid
 import qualified Data.SafeCopy          as SC
 import qualified Data.Text              as T
 import           Database.Redis         as R hiding (HostName, time)
@@ -199,7 +202,16 @@ timeI nm hostDimPolicy rawDims i act = do
 
 -------------------------------------------------------------------------------
 timerMetricName :: MetricName -> MetricName
-timerMetricName name = MetricName ("time." ++ metricName name)
+timerMetricName name@(MetricName nameS) =
+  if timerMetricNamePrefix `isPrefixOf` nameS
+     then name
+     else MetricName (timerMetricNamePrefix <> nameS)
+
+
+-------------------------------------------------------------------------------
+timerMetricNamePrefix :: String
+timerMetricNamePrefix = "time."
+
 
 -------------------------------------------------------------------------------
 -- | Sometimes dimensions are determined within a code block that

--- a/instrument/src/Instrument/Client.hs
+++ b/instrument/src/Instrument/Client.hs
@@ -8,6 +8,7 @@ module Instrument.Client
     , submitTime
     , incrementI
     , countI
+    , timerMetricName
     ) where
 
 -------------------------------------------------------------------------------
@@ -195,8 +196,12 @@ timeI name hostDimPolicy rawDims i act = do
   submitTime nm hostDimPolicy rawDims secs i
   return res
   where
-    nm = MetricName ("time." ++ metricName name)
+    nm = timerMetricName name
 
+
+-------------------------------------------------------------------------------
+timerMetricName :: MetricName -> MetricName
+timerMetricName name = MetricName ("time." ++ metricName name)
 
 -------------------------------------------------------------------------------
 -- | Sometimes dimensions are determined within a code block that

--- a/instrument/src/Instrument/Types.hs
+++ b/instrument/src/Instrument/Types.hs
@@ -22,6 +22,7 @@ module Instrument.Types
   , Stats(..)
   , hostDimension
   , HostDimensionPolicy(..)
+  , Quantile(..)
   ) where
 
 -------------------------------------------------------------------------------
@@ -288,7 +289,16 @@ instance Default Stats where
 instance Serialize Stats
 
 
+-------------------------------------------------------------------------------
+-- | Integer quantile, valid values range from 1-99, inclusive.
+newtype Quantile = Q { quantile :: Int } deriving (Show, Eq, Ord)
 
+instance Bounded Quantile where
+  minBound = Q 1
+  maxBound = Q 99
+
+
+-------------------------------------------------------------------------------
 $(SC.deriveSafeCopy 0 'SC.base ''Payload)
 $(SC.deriveSafeCopy 0 'SC.base ''SubmissionPacket_v0)
 $(SC.deriveSafeCopy 1 'SC.extension ''SubmissionPacket)

--- a/instrument/src/Instrument/Types.hs
+++ b/instrument/src/Instrument/Types.hs
@@ -19,8 +19,6 @@ module Instrument.Types
   , Payload(..)
   , Aggregated(..)
   , AggPayload(..)
-  , mkStatsFields
-  , aggToCSV
   , Stats(..)
   , hostDimension
   , HostDimensionPolicy(..)
@@ -29,11 +27,10 @@ module Instrument.Types
 -------------------------------------------------------------------------------
 import           Control.Applicative   as A
 import qualified Data.ByteString.Char8 as B
-import           Data.CSV.Conduit
 import           Data.Default
 import           Data.IORef
 import qualified Data.Map              as M
-import           Data.Monoid
+import           Data.Monoid           as Monoid
 import qualified Data.SafeCopy         as SC
 import           Data.Serialize
 import           Data.Serialize.Text   ()
@@ -46,7 +43,6 @@ import           Network.HostName
 -------------------------------------------------------------------------------
 import qualified Instrument.Counter    as C
 import qualified Instrument.Sampler    as S
-import           Instrument.Utils
 -------------------------------------------------------------------------------
 
 
@@ -239,7 +235,7 @@ upgradeAggregated_v1 a = Aggregated
   { aggTS = aggTS_v1 a
   , aggName = aggName_v1 a
   , aggPayload = aggPayload_v1 a
-  , aggDimensions = mempty
+  , aggDimensions = Monoid.mempty
   }
 
 
@@ -271,46 +267,6 @@ instance Default Aggregated where
 
 
 -------------------------------------------------------------------------------
--- | Get agg results into a form ready to be output
-mkStatsFields :: Aggregated -> ([(Text, Text)], Text)
-mkStatsFields Aggregated{..}  = (els, ts)
-    where
-      els =
-        case aggPayload of
-          AggStats Stats{..} ->
-              [ ("mean", formatDecimal 6 False smean)
-              , ("count", showT scount)
-              , ("max", formatDecimal 6 False smax)
-              , ("min", formatDecimal 6 False smin)
-              , ("srange", formatDecimal 6 False srange)
-              , ("stdDev", formatDecimal 6 False sstdev)
-              , ("sum", formatDecimal 6 False ssum)
-              , ("skewness", formatDecimal 6 False sskewness)
-              , ("kurtosis", formatDecimal 6 False skurtosis)
-              ] ++ (map mkQ $ M.toList squantiles)
-          AggCount i ->
-              [ ("count", showT i)]
-
-      mkQ (k,v) = (T.concat ["percentile_", showT k], formatDecimal 6 False v)
-      ts = formatInt aggTS
-
-
--------------------------------------------------------------------------------
--- | Expand count aggregation to have the full columns
-aggToCSV :: Aggregated -> M.Map Text Text
-aggToCSV agg@Aggregated{..} = els <> defFields <> dimFields
-  where
-    els :: MapRow Text
-    els = M.fromList $
-            ("metric", T.pack (metricName aggName)) :
-            ("timestamp", ts) :
-            fields
-    (fields, ts) = mkStatsFields agg
-    defFields = M.fromList $ fst $ mkStatsFields $ agg { aggPayload =  (AggStats def) }
-    dimFields = M.fromList [(k,v) | (DimensionName k, DimensionValue v) <- M.toList aggDimensions]
-
-
--------------------------------------------------------------------------------
 data Stats = Stats {
       smean      :: Double
     , ssum       :: Double
@@ -327,9 +283,7 @@ data Stats = Stats {
 
 
 instance Default Stats where
-    def = Stats 0 0 0 0 0 0 0 0 0 (M.fromList $ mkQ 99 : map (mkQ . (* 10)) [1..9])
-      where
-        mkQ i = (i, 0)
+    def = Stats 0 0 0 0 0 0 0 0 0 mempty
 
 instance Serialize Stats
 

--- a/instrument/src/Instrument/Worker.hs
+++ b/instrument/src/Instrument/Worker.hs
@@ -244,15 +244,6 @@ data AggProcess = AggProcess
 
 
 -------------------------------------------------------------------------------
--- | Integer quantile, valid values range from 1-99, inclusive.
-newtype Quantile = Q { quantile :: Int } deriving (Show, Eq, Ord)
-
-instance Bounded Quantile where
-  minBound = Q 1
-  maxBound = Q 99
-
-
--------------------------------------------------------------------------------
 -- | General configuration for agg processes. Defaulted with 'def' and 'defAggProcessConfig'
 data AggProcessConfig = AggProcessConfig
   { metricQuantiles :: MetricName -> Set.Set Quantile

--- a/instrument/src/Instrument/Worker.hs
+++ b/instrument/src/Instrument/Worker.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Instrument.Worker
     ( initWorkerCSV
@@ -8,7 +9,13 @@ module Instrument.Worker
     , initWorkerGraphite'
     , work
     , initWorker
-    , AggProcess
+    , AggProcess(..)
+    -- * Configuring agg processes
+    , AggProcessConfig(..)
+    , standardQuantiles
+    , noQuantiles
+    , quantileMap
+    , defAggProcessConfig
     -- * Exported for testing
     , expandDims
     ) where
@@ -35,6 +42,7 @@ import           Statistics.Sample
 import           System.IO
 import           System.Posix
 -------------------------------------------------------------------------------
+import           Instrument.Client      (timerMetricName)
 import qualified Instrument.Measurement as TM
 import           Instrument.Types
 import           Instrument.Utils
@@ -50,9 +58,10 @@ initWorkerCSV
   -- ^ Target file name
   -> Int
   -- ^ Aggregation period / flush interval in seconds
+  -> AggProcessConfig
   -> IO ()
-initWorkerCSV conn fp n =
-  initWorker "CSV Worker" conn n =<< initWorkerCSV' fp
+initWorkerCSV conn fp n cfg =
+  initWorker "CSV Worker" conn n =<< initWorkerCSV' fp cfg
 
 
 -------------------------------------------------------------------------------
@@ -61,15 +70,15 @@ initWorkerCSV conn fp n =
 initWorkerCSV'
   :: FilePath
   -- ^ Target file name
-  -- ^ Aggregation period / flush interval in seconds
+  -> AggProcessConfig
   -> IO AggProcess
-initWorkerCSV' fp = do
+initWorkerCSV' fp cfg = do
   !res <- fileExist fp
   !h <- openFile fp AppendMode
   hSetBuffering h LineBuffering
   unless res $
     T.hPutStrLn h $ rowToStr defCSVSettings . M.keys $ aggToCSV def
-  return $ putAggregateCSV h
+  return $ putAggregateCSV h cfg
 
 
 -------------------------------------------------------------------------------
@@ -83,9 +92,10 @@ initWorkerGraphite
     -- ^ Graphite host
     -> Int
     -- ^ Graphite port
+    -> AggProcessConfig
     -> IO ()
-initWorkerGraphite conn n server port =
-    initWorker "Graphite Worker" conn n =<< initWorkerGraphite' server port
+initWorkerGraphite conn n server port cfg =
+    initWorker "Graphite Worker" conn n =<< initWorkerGraphite' server port cfg
 
 
 -------------------------------------------------------------------------------
@@ -96,11 +106,12 @@ initWorkerGraphite'
     -- ^ Graphite host
     -> Int
     -- ^ Graphite port
+    -> AggProcessConfig
     -> IO AggProcess
-initWorkerGraphite' server port = do
+initWorkerGraphite' server port cfg = do
     h <- connectTo server (PortNumber $ fromIntegral port)
     hSetBuffering h LineBuffering
-    return $ putAggregateGraphite h
+    return $ putAggregateGraphite h cfg
 
 
 -------------------------------------------------------------------------------
@@ -117,19 +128,19 @@ initWorker wname conn n f = do
 
 -------------------------------------------------------------------------------
 -- | Extract statistics out of the given sample for this flush period
-mkStats :: Sample -> Stats
-mkStats s = Stats { smean = mean s
-                  , ssum = V.sum s
-                  , scount = V.length s
-                  , smax = V.maximum s
-                  , smin = V.minimum s
-                  , srange = range s
-                  , sstdev = stdDev s
-                  , sskewness = skewness s
-                  , skurtosis = kurtosis s
-                  , squantiles = quantiles }
+mkStats :: Set.Set Quantile -> Sample -> Stats
+mkStats qs s = Stats { smean = mean s
+                     , ssum = V.sum s
+                     , scount = V.length s
+                     , smax = V.maximum s
+                     , smin = V.minimum s
+                     , srange = range s
+                     , sstdev = stdDev s
+                     , sskewness = skewness s
+                     , skurtosis = kurtosis s
+                     , squantiles = quantiles }
   where
-    quantiles = M.fromList $ mkQ 100 99 : map (mkQ 100 . (* 10)) [1..9]
+    quantiles = M.fromList (mkQ 100 . quantile <$> Set.toList qs)
     mkQ mx i = (i, Q.weightedAvg i mx s)
 
 
@@ -153,17 +164,19 @@ processSampler
     -> B.ByteString
     -- ^ Redis buffer for this metric
     -> Redis ()
-processSampler n f k = do
+processSampler n (AggProcess cfg f) k = do
   packets <- popLAll k
   case packets of
     [] -> return ()
     _ -> do
       let nm = spName . head $ packets
+          -- have to prefix the timer prefix to make sure we catch those too
+          qs = quantilesFn nm <> quantilesFn (timerMetricName nm)
           byDims :: M.Map Dimensions [SubmissionPacket]
           byDims = collect packets spDimensions id
           mkAgg xs =
               case spPayload $ head xs of
-                Samples _ -> AggStats . mkStats . V.fromList .
+                Samples _ -> AggStats . mkStats qs . V.fromList .
                              concatMap (unSamples . spPayload) $
                              xs
                 Counter _ -> AggCount . sum .
@@ -174,6 +187,8 @@ processSampler n f k = do
           mkDimsAgg (dims, ps) = Aggregated t nm (mkAgg ps) dims
       mapM_ f aggs
       return ()
+  where
+    quantilesFn = metricQuantiles cfg
 
 
 -------------------------------------------------------------------------------
@@ -222,15 +237,70 @@ expandDims m =
 
 -- | A function that does something with the aggregation results. Can
 -- implement multiple backends simply using this.
-type AggProcess = Aggregated -> Redis ()
+data AggProcess = AggProcess
+  { apConfig :: AggProcessConfig
+  , apProc   :: Aggregated -> Redis ()
+  }
 
+
+-------------------------------------------------------------------------------
+-- | Integer quantile, valid values range from 1-99, inclusive.
+newtype Quantile = Q { quantile :: Int } deriving (Show, Eq, Ord)
+
+instance Bounded Quantile where
+  minBound = Q 1
+  maxBound = Q 99
+
+
+-------------------------------------------------------------------------------
+-- | General configuration for agg processes. Defaulted with 'def' and 'defAggProcessConfig'
+data AggProcessConfig = AggProcessConfig
+  { metricQuantiles :: MetricName -> Set.Set Quantile
+  -- ^ What quantiles should we calculate for any given metric, if
+  -- any? We offer some common patterns for this in 'quantileMap',
+  -- 'standardQuantiles', and 'noQuantiles'.
+  }
+
+
+-- | Uses 'standardQuantiles'.
+defAggProcessConfig :: AggProcessConfig
+defAggProcessConfig = AggProcessConfig standardQuantiles
+
+
+instance Default AggProcessConfig where
+  def = defAggProcessConfig
+
+
+-- | Regardless of metric, produce no quantiles.
+noQuantiles :: MetricName -> [Quantile]
+noQuantiles = const mempty
+
+
+-- | This is usually a good, comprehensive default. Produces quantiles
+-- 10,20,30,40,50,60,70,80,90,99. *Note:* for some backends like
+-- cloudwatch, each quantile produces an additional metric, so you
+-- should probably consider using something more limited than this.
+standardQuantiles :: MetricName -> Set.Set Quantile
+standardQuantiles _ =
+  Set.fromList [Q 10,Q 20,Q 30,Q 40,Q 50,Q 60,Q 70,Q 80,Q 90,Q 99]
+
+
+-- | If you have a fixed set of metric names, this is often a
+-- convenient way to express quantiles-per-metric.
+quantileMap
+  :: M.Map MetricName (Set.Set Quantile)
+  -> Set.Set Quantile
+  -- ^ What to return on miss
+  -> (MetricName -> Set.Set Quantile)
+quantileMap m qdef mn = fromMaybe qdef (M.lookup mn m)
 
 
 -------------------------------------------------------------------------------
 -- | Store aggregation results in a CSV file
-putAggregateCSV :: Handle -> AggProcess
-putAggregateCSV h agg = liftIO $ T.hPutStrLn h d
-  where d = rowToStr defCSVSettings $ aggToCSV agg
+putAggregateCSV :: Handle -> AggProcessConfig -> AggProcess
+putAggregateCSV h cfg = AggProcess cfg $ \agg ->
+  let d = rowToStr defCSVSettings $ aggToCSV agg
+  in liftIO $ T.hPutStrLn h d
 
 
 typePrefix :: AggPayload -> T.Text
@@ -240,20 +310,20 @@ typePrefix AggCount{} = "counts"
 
 -------------------------------------------------------------------------------
 -- | Push data into a Graphite database using the plaintext protocol
-putAggregateGraphite :: Handle -> AggProcess
-putAggregateGraphite h agg = liftIO $ mapM_ (mapM_ (T.hPutStrLn h) . mkLines) ss
-    where
-      (ss, ts) = mkStatsFields agg
-      -- Expand dimensions into one datum per dimension pair as the group
-      mkLines (m, val) = for (M.toList (aggDimensions agg)) $ \(DimensionName dimName, DimensionValue dimVal) -> T.concat
-          [ "inst."
-          , typePrefix (aggPayload agg), "."
-          ,  T.pack (metricName (aggName agg)), "."
-          , m, "."
-          , dimName, "."
-          , dimVal, " "
-          , val, " "
-          , ts ]
+putAggregateGraphite :: Handle -> AggProcessConfig -> AggProcess
+putAggregateGraphite h cfg = AggProcess cfg $ \agg ->
+    let (ss, ts) = mkStatsFields agg
+        -- Expand dimensions into one datum per dimension pair as the group
+        mkLines (m, val) = for (M.toList (aggDimensions agg)) $ \(DimensionName dimName, DimensionValue dimVal) -> T.concat
+            [ "inst."
+            , typePrefix (aggPayload agg), "."
+            ,  T.pack (metricName (aggName agg)), "."
+            , m, "."
+            , dimName, "."
+            , dimVal, " "
+            , val, " "
+            , ts ]
+    in liftIO $ mapM_ (mapM_ (T.hPutStrLn h) . mkLines) ss
 
 
 -------------------------------------------------------------------------------
@@ -288,3 +358,43 @@ dbg _ = return ()
 -- ------------------------------------------------------------------------------
 -- dbg :: (MonadIO m) => String -> m ()
 -- dbg s = debug $ "Instrument.Worker: " ++ s
+
+
+-------------------------------------------------------------------------------
+-- | Expand count aggregation to have the full columns
+aggToCSV :: Aggregated -> M.Map T.Text T.Text
+aggToCSV agg@Aggregated{..} = els <> defFields <> dimFields
+  where
+    els :: MapRow T.Text
+    els = M.fromList $
+            ("metric", T.pack (metricName aggName)) :
+            ("timestamp", ts) :
+            fields
+    (fields, ts) = mkStatsFields agg
+    defFields = M.fromList $ fst $ mkStatsFields $ agg { aggPayload =  (AggStats def) }
+    dimFields = M.fromList [(k,v) | (DimensionName k, DimensionValue v) <- M.toList aggDimensions]
+
+
+-------------------------------------------------------------------------------
+-- | Get agg results into a form ready to be output
+mkStatsFields :: Aggregated -> ([(T.Text, T.Text)], T.Text)
+mkStatsFields Aggregated{..}  = (els, ts)
+    where
+      els =
+        case aggPayload of
+          AggStats Stats{..} ->
+              [ ("mean", formatDecimal 6 False smean)
+              , ("count", showT scount)
+              , ("max", formatDecimal 6 False smax)
+              , ("min", formatDecimal 6 False smin)
+              , ("srange", formatDecimal 6 False srange)
+              , ("stdDev", formatDecimal 6 False sstdev)
+              , ("sum", formatDecimal 6 False ssum)
+              , ("skewness", formatDecimal 6 False sskewness)
+              , ("kurtosis", formatDecimal 6 False skurtosis)
+              ] ++ (map mkQ $ M.toList squantiles)
+          AggCount i ->
+              [ ("count", showT i)]
+
+      mkQ (k,v) = (T.concat ["percentile_", showT k], formatDecimal 6 False v)
+      ts = formatInt aggTS

--- a/instrument/src/Instrument/Worker.hs
+++ b/instrument/src/Instrument/Worker.hs
@@ -42,7 +42,7 @@ import           Statistics.Sample
 import           System.IO
 import           System.Posix
 -------------------------------------------------------------------------------
-import           Instrument.Client      (timerMetricName)
+import           Instrument.Client      (stripTimerPrefix, timerMetricName)
 import qualified Instrument.Measurement as TM
 import           Instrument.Types
 import           Instrument.Utils
@@ -170,8 +170,8 @@ processSampler n (AggProcess cfg f) k = do
     [] -> return ()
     _ -> do
       let nm = spName . head $ packets
-          -- have to prefix the timer prefix to make sure we catch those too
-          qs = quantilesFn nm <> quantilesFn (timerMetricName nm)
+          -- with and without timer prefix
+          qs = quantilesFn (stripTimerPrefix nm) <> quantilesFn (timerMetricName nm)
           byDims :: M.Map Dimensions [SubmissionPacket]
           byDims = collect packets spDimensions id
           mkAgg xs =

--- a/instrument/test/src/Instrument/Tests/Arbitrary.hs
+++ b/instrument/test/src/Instrument/Tests/Arbitrary.hs
@@ -18,3 +18,7 @@ instance Arbitrary DimensionName where
 
 instance Arbitrary DimensionValue where
   arbitrary = DimensionValue <$> arbitrary
+
+
+instance Arbitrary MetricName where
+  arbitrary = MetricName <$> arbitrary

--- a/instrument/test/src/Instrument/Tests/Client.hs
+++ b/instrument/test/src/Instrument/Tests/Client.hs
@@ -34,7 +34,7 @@ queue_bounding_test mkConn = do
     -- bounds will drop these
     sampleI key DoNotAddHostDimension dims 100 instr
     sleepFlush
-    void $ forkIO $ work conn 1 (liftIO . putMVar agg)
+    void $ forkIO $ work conn 1 (AggProcess defAggProcessConfig (liftIO . putMVar agg))
     Aggregated { aggPayload = AggStats Stats {..} } <- takeMVar agg
     assertEqual "throws away newer data exceeding bounds"
                 (2, 1, 1, 2)


### PR DESCRIPTION
@ozataman I'd like a review of the approach I took here. This adds a config record to AggProcess, so that it isn't just a type alias for the aggregation function. This config record has a field with a function mapping from metric name to a set of quantiles and some combinators for common formulations of that mapping. Now that the user can limit quantiles per-worker, the cloudwatch worker can actually take any quantiles that make it through and publish them as sub metrics. My initial tests of this appear to be working correctly.

I explain in the commit log but I decided to use a function because not all setups can enumerate all of the metric names to just make a simple `Map MetricName (Set Quantile)`. Some metric backends may bake some dimension info into the metric name, and thus they would want to match on names with a function.

I'm currently dogfooding this internally and it appears to work. If you prefer, you can forgo merging this until we have mileage in production, but let me know if you approve of the direction.