### PR TITLE
GHC 9 compatibility

### DIFF
--- a/instrument-cloudwatch/instrument-cloudwatch.cabal
+++ b/instrument-cloudwatch/instrument-cloudwatch.cabal
@@ -22,7 +22,7 @@ library
   build-depends:       base >= 4.6 && < 5
                      , amazonka-cloudwatch >= 2
                      , instrument >= 0.4.0.0
-                     , lens >= 4.7 && < 5
+                     , lens >= 4.7 && <= 5.2 
                      , text
                      , time >= 1.4.2
                      , async >= 2.0.2


### PR DESCRIPTION
This reorders declarations to comply with GHC 9 changes and relaxes the lens upper bound since newer lens versions are brought in in package sets like LTS and nixpkgs with GHC 9. Tested with 8.10.7, 9.2.5 and 9.4.4.

See 9.0.1 [release notes](https://downloads.haskell.org/ghc/9.0.1/docs/html/users_guide/9.0.1-notes.html) for more info on the template haskell breaking change.