### PR TITLE
Bump maximum dimension count to 30

### DIFF
--- a/instrument-cloudwatch/src/Instrument/CloudWatch.hs
+++ b/instrument-cloudwatch/src/Instrument/CloudWatch.hs
@@ -185,7 +185,7 @@ toDatum a =
     ts = aggTS a ^. timeDouble
     dims = uncurry mkDim <$> take maxDimensions (M.toList (aggDimensions a))
     mkDim (DimensionName dn) (DimensionValue dv) = CW.newDimension dn dv
-    maxDimensions = 10
+    maxDimensions = 30
 
 -------------------------------------------------------------------------------
 timeDouble :: Iso' Double UTCTime


### PR DESCRIPTION
According to Amazon's [announcement in Aug 2022](https://aws.amazon.com/about-aws/whats-new/2022/08/amazon-cloudwatch-metrics-increases-throughput/) AWS CloudWatch now allows up to 30 dimensions.