### PR TITLE
Limit CW chunks by size

### DIFF
--- a/instrument-cloudwatch/instrument-cloudwatch.cabal
+++ b/instrument-cloudwatch/instrument-cloudwatch.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 45a7868ec4ece5cdab9ce777fe13ccc998ea3e1d4f4fd04278e45dade56d3034
+-- hash: c64b6295bb6aa1d83a47a8fe5e1278273eb8fcb48f4f8990adda548483f2e12c
 
 name:           instrument-cloudwatch
 version:        0.2.1.0
@@ -31,8 +31,10 @@ library
   build-depends:
       amazonka >=1.6.1
     , amazonka-cloudwatch >=2
+    , amazonka-core >=2
     , async >=2.0.2
     , base >=4.6 && <5
+    , bytestring
     , containers
     , instrument >=0.4.0.0
     , lens >=4.7 && <=5.2
@@ -61,9 +63,13 @@ test-suite test
       QuickCheck
     , amazonka >=1.6.1
     , amazonka-cloudwatch >=2
+    , amazonka-core >=2
     , async >=2.0.2
     , base >=4.6 && <5
+    , bytestring
     , containers
+    , data-default
+    , hedis
     , instrument >=0.4.0.0
     , lens >=4.7 && <=5.2
     , retry >=0.7

--- a/instrument-cloudwatch/package.yaml
+++ b/instrument-cloudwatch/package.yaml
@@ -18,7 +18,9 @@ default-extensions: []
 
 dependencies:
   - base >= 4.6 && < 5
+  - bytestring
   - amazonka-cloudwatch >= 2
+  - amazonka-core >= 2
   - instrument >= 0.4.0.0
   - lens >= 4.7 && <= 5.2
   - text
@@ -53,10 +55,12 @@ tests:
       - -threaded
       - -rtsopts
     dependencies:
-      - tasty >= 0.10
-      - tasty-hunit >= 0.9
+      - data-default
+      - hedis
+      - QuickCheck
+      - semigroups
       - stm
       - stm-chans
-      - semigroups
+      - tasty >= 0.10
+      - tasty-hunit >= 0.9
       - tasty-quickcheck >= 0.8.4
-      - QuickCheck

--- a/instrument-cloudwatch/test/Instrument/Tests/CloudWatch.hs
+++ b/instrument-cloudwatch/test/Instrument/Tests/CloudWatch.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -7,14 +10,27 @@ module Instrument.Tests.CloudWatch
 where
 
 -------------------------------------------------------------------------------
+
+import qualified Amazonka as AWS
+import qualified Amazonka.CloudWatch as CW
+import Control.Concurrent
+import Control.Concurrent.Async
 import Control.Concurrent.STM
 import Control.Concurrent.STM.TBMQueue
+import Control.Monad
+import Data.Default
 import qualified Data.Foldable as FT
+import Data.Functor
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as M
 import Data.Semigroup
+import qualified Data.Text as T
+import Database.Redis
 -------------------------------------------------------------------------------
+import Instrument
 import Instrument.CloudWatch
+import qualified System.IO as IO
 import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -27,7 +43,8 @@ tests =
   testGroup
     "Instrument.CloudWatch"
     [ slurpTBMQueueTests,
-      splitNETests
+      splitNEWithSizeTests,
+      cloudWatchTests
     ]
 
 -------------------------------------------------------------------------------
@@ -53,25 +70,145 @@ slurpTBMQueueTests =
         res @?= Just ("one" :| [])
     ]
 
+cloudWatchTests :: TestTree
+cloudWatchTests =
+  testGroup
+    "CloudWatch"
+    [ withRedisCleanup $ testCase "works with bounded size/count limitation" . cloudwatch_size_limitation
+    ]
+
+cloudwatch_size_limitation :: IO Connection -> IO ()
+cloudwatch_size_limitation mkConn = do
+  conn <- mkConn
+  instr <- initInstrument redisCI icfg
+  forM_ [(1 :: Integer) .. 10000] $ \n ->
+    let newDims = M.insert (DimensionName "test_id") (DimensionValue (T.pack (show n))) dims
+     in sampleI key DoNotAddHostDimension newDims 1 instr
+
+  threadDelay 10000000
+
+  awsEnv <- initAWSEnv
+
+  let cfg = mkDefCloudWatchICfg "test-namespace" awsEnv
+  (aggProcess, _finalize) <- cloudWatchAggProcess cfg
+
+  let worker = work conn 1 aggProcess
+  withAsync worker $ \_ -> do
+    threadDelay 10000000
+    assertEqual
+      "throws away newer data exceeding bounds"
+      (1 :: Integer)
+      1
+
 -------------------------------------------------------------------------------
 mkQueue :: Int -> IO (TBMQueue String)
 mkQueue = newTBMQueueIO
 
 -------------------------------------------------------------------------------
-splitNETests :: TestTree
-splitNETests =
+newtype DataWithSize = DataWithSize {_dataWithSize :: Int}
+  deriving newtype (Show, Eq, Num, Arbitrary)
+
+instance HasSize DataWithSize where
+  calculateSize (DataWithSize a) = a
+
+splitNEWithSizeTests :: TestTree
+splitNEWithSizeTests =
   testGroup
-    "splitNE"
-    [ testProperty "0 or negative count" $ \(NonEmpty nel) n ->
-        n <= 0 ==>
-          let ne = NE.fromList nel :: NonEmpty ()
-           in splitNE n ne === ne :| [],
-      testProperty "positive count, no items exceed length" $ \(NonEmpty nel) (Positive n) ->
-        let ne = NE.fromList nel :: NonEmpty ()
-            res = splitNE n ne
+    "splitNEWithSize"
+    [ testProperty "0 or negative size" $ \(NonEmpty nel) n ->
+        n
+          <= 0
+          ==> let ne = NE.fromList nel :: NonEmpty DataWithSize
+               in splitNEWithSize (MaxSize n) (MaxCount 10000) ne === ne :| [],
+      testCase "positive size, no items exceed length" $ do
+        let ne = NE.fromList $ take 1000 (DataWithSize <$> cycle [1 .. 10])
+            -- some random max size that is bigger than any single item
+            maxChunkSize = MaxSize 123
+            maxCount = MaxCount 10000
+            res = splitNEWithSize maxChunkSize maxCount ne
+
+        forM_ res $ \chunk ->
+          assertBool "chunk's total size must not be bigger than the maxChunkSize" (sum (fmap calculateSize chunk) <= unMaxSize maxChunkSize),
+      testCase "positive size, have the correct set of chunks" $ do
+        let d = DataWithSize 3
+            ne = NE.fromList $ replicate 100 d
+            maxChunkSize = MaxSize 10
+            maxCount = MaxCount 10000
+            res = splitNEWithSize maxChunkSize maxCount ne
+
+        -- total size is 300
+        -- each chunk would get 3 d's (with a total size of 9 for each chunk)
+        -- so we should observe 33 full chunks and a single one-item chunk
+        res @?= NE.fromList (fmap NE.fromList (replicate 33 (replicate 3 d) <> [replicate 1 d])),
+      testProperty "positive size, loses no items and preserves order" $ \(NonEmpty nel) (Positive n) ->
+        let ne = NE.fromList nel :: NonEmpty DataWithSize
+            maxCount = MaxCount 10000
+            res = splitNEWithSize (MaxSize n) maxCount ne
+         in sconcat res === ne,
+      testProperty "0 or negative count" $ \(NonEmpty nel) n ->
+        n
+          <= 0
+          ==> let ne = NE.fromList nel :: NonEmpty DataWithSize
+               in splitNEWithSize (MaxSize 10000) (MaxCount n) ne === ne :| [],
+      testProperty "positive count, no items exceed maxCount" $ \(Positive n) ->
+        let ne = NE.fromList $ take 1000 (DataWithSize <$> cycle [1 .. 10])
+            -- some random max size that is bigger than any single item
+            maxChunkSize = MaxSize 100000
+            maxCount = MaxCount n
+            res = splitNEWithSize maxChunkSize maxCount ne
          in FT.all ((<= n) . NE.length) res,
+      testCase "positive count, have the correct set of chunks" $ do
+        let d = DataWithSize 3
+            ne = NE.fromList $ replicate 101 d
+            maxChunkSize = MaxSize 100000
+            maxCount = MaxCount 10
+            res = splitNEWithSize maxChunkSize maxCount ne
+
+        -- total size is 300
+        -- each chunk would get 3 d's (with a total size of 9 for each chunk)
+        -- so we should observe 33 full chunks and a single one-item chunk
+        res @?= NE.fromList (fmap NE.fromList (replicate 10 (replicate 10 d) <> [replicate 1 d])),
       testProperty "positive count, loses no items and preserves order" $ \(NonEmpty nel) (Positive n) ->
-        let ne = NE.fromList nel :: NonEmpty ()
-            res = splitNE n ne
-         in sconcat res === ne
+        let ne = NE.fromList nel :: NonEmpty DataWithSize
+            maxChunkSize = MaxSize 100000
+            maxCount = MaxCount n
+            res = splitNEWithSize maxChunkSize maxCount ne
+         in sconcat res === ne,
+      testProperty "no chunk exceeds maxChunkSize or maxCount" $ \(NonEmpty nel) (Positive mSize) (Positive mCount) ->
+        (mSize > maximum (fmap calculateSize nel)) ==>
+          let ne = NE.fromList nel :: NonEmpty DataWithSize
+              maxChunkSize = MaxSize mSize
+              maxCount = MaxCount mCount
+              res = splitNEWithSize maxChunkSize maxCount ne
+           in FT.all (\chunk -> (NE.length chunk <= mCount) && sum (fmap calculateSize chunk) <= mSize) res
     ]
+
+-------------------------------------------------------------------------------
+withRedisCleanup :: (IO Connection -> TestTree) -> TestTree
+withRedisCleanup = withResource (connect redisCI) cleanup
+  where
+    cleanup conn = void $
+      runRedis conn $ do
+        ks <- either mempty id <$> smembers packetsKey
+        _ <- del (packetsKey : ks)
+        quit
+
+-------------------------------------------------------------------------------
+redisCI :: ConnectInfo
+redisCI = defaultConnectInfo {connectPort = PortNumber 6380}
+
+icfg :: InstrumentConfig
+icfg = def {redisQueueBound = Just 2}
+
+key :: MetricName
+key = MetricName "instrument-test"
+
+dims :: Dimensions
+dims = M.fromList [(DimensionName "server", DimensionValue "app1")]
+
+initAWSEnv :: IO AWS.Env
+initAWSEnv = do
+  logger <- AWS.newLogger AWS.Debug IO.stdout
+  AWS.newEnv AWS.discover <&> \e -> (foldr AWS.configureService e overrides) {AWS.logger = logger}
+  where
+    overrides = [AWS.setEndpoint False "localhost" 4566 CW.defaultService]

--- a/instrument-cloudwatch/test/Instrument/Tests/CloudWatch.hs
+++ b/instrument-cloudwatch/test/Instrument/Tests/CloudWatch.hs
@@ -95,8 +95,9 @@ cloudwatch_size_limitation mkConn = do
   let worker = work conn 1 aggProcess
   withAsync worker $ \_ -> do
     threadDelay 10000000
+    -- TODO (koray) pull metrics from CloudWatch and compare
     assertEqual
-      "throws away newer data exceeding bounds"
+      "metric counts match to the ones that were pushed in CloudWatch"
       (1 :: Integer)
       1
 


### PR DESCRIPTION
According to the [announcement made by AWS](https://aws.amazon.com/about-aws/whats-new/2022/08/amazon-cloudwatch-metrics-increases-throughput/) the maximum number of metrics that can be sent via the PutMetricData endpoint has been increased from **20** to **1000** with a limitation on the body size of **1MB**.

Hence, with this MR, instead of pulling the first **20** metric data, we're instead calculating the QueryString size of each metric, and using 700KB as the upper limit, so that we have sufficient space for the fixed metric. We're using the below command to calculate the size for each single metric data:

``` haskell
BS.length (AWS.toBS (AWS.toQueryList "member" [md]))
``` 
which results in below query string:
```
member.1.Dimensions.member.1.Name=test_id
&member.1.Dimensions.member.1.Value=9970
&member.1.MetricName=instrument-test
&member.1.StatisticValues.Maximum=1.0
&member.1.StatisticValues.Minimum=1.0
&member.1.StatisticValues.SampleCount=1.0
&member.1.StatisticValues.Sum=1.0
&member.1.Timestamp=2023-07-26T15%3A27%3A39Z
```
of course the above calculation will always use `1` as the member id, so for the actual total payload size, the size will change depending on the index. for performance reasons, I think this is acceptable approximation on size calculation. We should be fine size we leave 300KB free.

----
Note: another (or better) improvement we can have for this endpoint is to [`gzip`](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html) the resulting payload (after pulling 1000 items). but that will require us to modify the request Amazonka is making. Since there's a lot of repetition in the payload, that may allow us to get rid of this calculation. On a raw payload in size **14130 Bytes**, gzipping it dropped the size to **1392 Bytes**
 