### PR TITLE
Update for GHC 9.6 Compatibility

### DIFF
--- a/instrument/src/Instrument/Utils.hs
+++ b/instrument/src/Instrument/Utils.hs
@@ -19,7 +19,6 @@ where
 
 -------------------------------------------------------------------------------
 import Codec.Compression.GZip
-import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException)
 import Control.Monad
@@ -101,7 +100,9 @@ encodeCompress = toStrict . compress . runPutLazy . SC.safePut
 decodeCompress :: (SC.SafeCopy a, Serialize a) => B.ByteString -> Either String a
 decodeCompress = decodeWithFallback . decompress . fromStrict
   where
-    decodeWithFallback lbs = runGetLazy SC.safeGet lbs <|> decodeLazy lbs
+    decodeWithFallback lbs = case runGetLazy SC.safeGet lbs of
+      x@(Right _) -> x
+      Left _ -> decodeLazy lbs
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
GHC 9.6 removed some instances, which result in build failures like the following:

```
src/Instrument/Utils.hs:104:56: error: [GHC-39999]
    • Could not deduce ‘GHC.Base.Alternative (Either String)’
        arising from a use of ‘<|>’
      from the context: (SC.SafeCopy a, Serialize a)
        bound by the type signature for:
                   decodeCompress :: forall a.
                                     (SC.SafeCopy a, Serialize a) =>
                                     B.ByteString -> Either String a
        at src/Instrument/Utils.hs:101:1-81
      or from: (SC.SafeCopy a1, Serialize a1)
        bound by the inferred type of
                   decodeWithFallback :: (SC.SafeCopy a1, Serialize a1) =>
                                         Data.ByteString.Lazy.Internal.ByteString
                                         -> Either String a1
        at src/Instrument/Utils.hs:104:5-73
    • In the expression: runGetLazy SC.safeGet lbs <|> decodeLazy lbs
      In an equation for ‘decodeWithFallback’:
          decodeWithFallback lbs
            = runGetLazy SC.safeGet lbs <|> decodeLazy lbs
      In an equation for ‘decodeCompress’:
          decodeCompress
            = decodeWithFallback . decompress . fromStrict
            where
                decodeWithFallback lbs
                  = runGetLazy SC.safeGet lbs <|> decodeLazy lbs
    |
104 |     decodeWithFallback lbs = runGetLazy SC.safeGet lbs <|> decodeLazy lbs
    |                                                        ^^^
```

This PR fixes the problem, while maintaining compatibility with older GHCs (9.4 in particular).
